### PR TITLE
Add DO_COMPONENT flag for per-component D-optimality cluster selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,65 @@ Documentation
 
 <hr>
 
+D-Optimality Cluster Selection
+------------------------
+
+When running cluster-based active learning (`DO_CLUSTER = True`), the driver must
+decide which of the many candidate atomic clusters extracted from MD trajectories
+are worth sending to expensive quantum (e.g. VASP) labeling. Two down-selection
+strategies are available:
+
+* **MC energy histogram (default):** `gen_subset()` performs a ChIMES "dumb-energy"
+  calculation for each candidate (`CLUENER_CALC`) and selects clusters that flatten
+  an energy histogram.
+* **D-optimality (maxvol):** `gen_subset_dopt()` selects clusters by *model
+  uncertainty* (extrapolation grade, gamma) using the maxvol algorithm. The
+  ChIMES dumb-energy calculation is skipped entirely.
+
+To enable the D-optimality path, set `DO_DOPT = True` (requires `DO_CLUSTER = True`).
+
+### How it works
+
+1. Stream-build a pseudo design matrix `A_atomic` from the current fit's reference
+   matrix (`GEN_FF/A_comb.txt`, or `A.txt`). Only the force rows are used; FITENER
+   energy rows are stripped. By default each atom's three force rows (`fx, fy, fz`)
+   are hstacked into a single row of width `3*n_feat`; see `DO_COMPONENT` below to
+   keep them separate.
+2. Run **maxvol** (from the `maxvolpy` package) to find the D-optimal square
+   sub-matrix, and invert it to obtain `inverse_A_subset`. This requires a *tall*
+   matrix (more rows than features); add more training data if it is not.
+3. Submit a `chimes_lsq` job to generate descriptors for the candidate clusters.
+4. Compute a per-cluster uncertainty `gamma = max(A_candidate @ inverse_A_subset)`.
+5. Keep clusters whose gamma falls in `[DOPT_GAMMA_MIN, DOPT_GAMMA_MAX]`. Below the
+   minimum, a cluster is already well-represented in the training set; above the
+   maximum, it is too far from the current model's domain of validity.
+6. Write `all.selection.dat` / `all.xyzlist.dat` and diagnostics
+   (`dopt_gamma_dist.pdf`, `dopt_cluster_gamma.txt`).
+
+If no candidate clusters exceed the gamma threshold and `DOPT_STOP_ON_EMPTY = True`,
+active learning is treated as converged: QM labeling is skipped and convergence is
+recorded in `restart.dat` so subsequent driver invocations do not continue. (At
+ALC-0 an empty selection is instead a fatal error, since active learning cannot
+start with nothing selected.)
+
+**Prerequisite:** `pip install maxvolpy`
+
+### Configuration flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `DO_DOPT` | bool | `False` | Use D-optimality (maxvol) for cluster down-selection instead of the MC energy histogram. Requires `DO_CLUSTER = True`. When `True`, the ChIMES dumb-energy calculation (`CLUENER_CALC`) is skipped. |
+| `DOPT_GAMMA_MIN` | float | `3.0` | Lower gamma bound. Clusters below this are considered already well-represented and are excluded. |
+| `DOPT_GAMMA_MAX` | float | `10.0` | Upper gamma bound. Clusters above this are considered too far from the model's domain of validity and are excluded. |
+| `DOPT_STOP_ON_EMPTY` | bool | `True` | Stop active learning (convergence) when D-opt selects zero clusters above the gamma threshold. Skips QM submission and records completion in `restart.dat`. |
+| `DO_COMPONENT` | bool | `False` | Controls how `A_atomic` is built. `False`: hstack each atom's `fx, fy, fz` into one row of width `3*n_feat` (maxvol/gamma operate per atom). `True`: leave the A matrix as-is — each force component row is kept separate (width `n_feat`), so each atom contributes three rows and maxvol/gamma operate per force component. FITENER energy rows are stripped in either case. |
+
+The `DOPT_*` and `DO_COMPONENT` flags are only read when `DO_DOPT = True`. A complete
+worked example is provided in
+[`examples/cluster_based_active_learning_single_statepoint-VASP-dopt/`](examples/cluster_based_active_learning_single_statepoint-VASP-dopt/).
+
+<hr>
+
 Community
 ------------------------
 

--- a/examples/cluster_based_active_learning_single_statepoint-VASP-dopt/config.py
+++ b/examples/cluster_based_active_learning_single_statepoint-VASP-dopt/config.py
@@ -97,6 +97,15 @@ DOPT_GAMMA_MAX = 10.0
 # Skips QM submission and records convergence in restart.dat.
 DOPT_STOP_ON_EMPTY = True
 
+# How the pseudo A matrix (A_atomic) is built before maxvol:
+#   False (default) - hstack each atom's three force rows (fx, fy, fz) into a
+#                     single row of width 3*n_feat; maxvol/gamma operate per atom.
+#   True            - leave the A matrix as-is: each force component row is kept
+#                     separate (width n_feat), so each atom contributes three
+#                     rows; maxvol/gamma operate per force component.
+# Energy (FITENER) rows are stripped either way.
+DO_COMPONENT = False
+
 # MEM_ECUT is still used as a pre-filter if DO_DOPT is False; kept here for
 # easy toggling between methods.
 MEM_ECUT = 4000.0

--- a/src/gen_selections.py
+++ b/src/gen_selections.py
@@ -845,11 +845,19 @@ def _read_amat_nfeat(amat_path):
         return len(_parse_a_line(f.readline()))
 
 
-def _fill_a_atomic_from_frames(fstream, A_atomic, atom_offset, frame_natoms, fitener):
+def _fill_a_atomic_from_frames(fstream, A_atomic, row_offset, frame_natoms, fitener,
+                               component=False):
     """
-    Read force rows from an open A matrix stream and write hstacked atomic rows.
+    Read force rows from an open A matrix stream and write rows into A_atomic.
 
-    Returns the updated atom_offset.
+    If component is False (default), the three force rows of each atom
+    (fx, fy, fz) are hstacked into one row of width 3*n_feat.
+    If component is True, each force row is written as-is (width n_feat), so
+    each atom contributes three separate rows.
+
+    In both cases FITENER energy rows are skipped per frame.
+
+    Returns the updated row_offset.
     """
     energy_skip = 3 if fitener else 0
 
@@ -858,21 +866,31 @@ def _fill_a_atomic_from_frames(fstream, A_atomic, atom_offset, frame_natoms, fit
             fx = _parse_a_line(fstream.readline())
             fy = _parse_a_line(fstream.readline())
             fz = _parse_a_line(fstream.readline())
-            A_atomic[atom_offset] = np.concatenate((fx, fy, fz))
-            atom_offset += 1
+            if component:
+                A_atomic[row_offset    ] = fx
+                A_atomic[row_offset + 1] = fy
+                A_atomic[row_offset + 2] = fz
+                row_offset += 3
+            else:
+                A_atomic[row_offset] = np.concatenate((fx, fy, fz))
+                row_offset += 1
 
         for _ in range(energy_skip):
             fstream.readline()
 
-    return atom_offset
+    return row_offset
 
 
 def _build_a_atomic_from_file(amat_path, fm_setup_path=None, traj_list_path=None,
-                              frame_natoms=None, fitener=None, label=""):
+                              frame_natoms=None, fitener=None, label="",
+                              component=False):
     """
     Stream-build A_atomic from A.txt without loading the full A matrix.
 
     Peak memory is one A_atomic array plus a few descriptor rows at a time.
+
+    If component is True, force rows are kept as-is (each atom yields three rows
+    of width n_feat) rather than hstacked into one row of width 3*n_feat.
     """
     if not os.path.exists(amat_path):
         print("ERROR (gen_subset_dopt): A matrix file not found:", amat_path)
@@ -915,35 +933,48 @@ def _build_a_atomic_from_file(amat_path, fm_setup_path=None, traj_list_path=None
         print("gen_subset_dopt: streaming {} force rows ({} atoms) from {}".format(
             n_rows, n_atoms, amat_path))
 
-    A_atomic   = np.empty((n_atoms, 3 * n_feat), dtype=np.float64)
-    atom_offset = 0
+    if component:
+        n_out_rows = 3 * n_atoms
+        row_width  = n_feat
+    else:
+        n_out_rows = n_atoms
+        row_width  = 3 * n_feat
+
+    A_atomic   = np.empty((n_out_rows, row_width), dtype=np.float64)
+    row_offset = 0
 
     with open(amat_path, 'r') as fstream:
-        atom_offset = _fill_a_atomic_from_frames(
-            fstream, A_atomic, atom_offset, frame_natoms, bool(fitener))
+        row_offset = _fill_a_atomic_from_frames(
+            fstream, A_atomic, row_offset, frame_natoms, bool(fitener), component)
 
-    if atom_offset != n_atoms:
+    if row_offset != n_out_rows:
         print("ERROR (gen_subset_dopt): {} expected {} atomic rows but read {}.".format(
-            label or amat_path, n_atoms, atom_offset))
+            label or amat_path, n_out_rows, row_offset))
         exit()
 
     return A_atomic, n_feat
 
 
-def _compute_cluster_gamma_from_amat(cand_amat_path, inverse_a_subset, all_clusters):
+def _compute_cluster_gamma_from_amat(cand_amat_path, inverse_a_subset, all_clusters,
+                                     component=False):
     """
     Compute per-cluster max gamma by streaming the candidate A matrix.
 
     Avoids building the full A_atomic_cand array in memory.
+
+    If component is True, each force row (fx, fy, fz) is scored on its own
+    against inverse_a_subset (width n_feat); otherwise the three rows are
+    hstacked into one atom row (width 3*n_feat) before scoring.
     """
     cluster_gamma = []
     n_atoms_total = 0
     n_feat        = _read_amat_nfeat(cand_amat_path)
 
-    if inverse_a_subset.shape[0] != 3 * n_feat:
+    expected_width = n_feat if component else 3 * n_feat
+    if inverse_a_subset.shape[0] != expected_width:
         print("ERROR (gen_subset_dopt): inverse_A_subset width {} does not match "
               "candidate descriptor width {}.".format(
-                  inverse_a_subset.shape[0], 3 * n_feat))
+                  inverse_a_subset.shape[0], expected_width))
         exit()
 
     with open(cand_amat_path, 'r') as fstream:
@@ -954,9 +985,14 @@ def _compute_cluster_gamma_from_amat(cand_amat_path, inverse_a_subset, all_clust
                 fx = _parse_a_line(fstream.readline())
                 fy = _parse_a_line(fstream.readline())
                 fz = _parse_a_line(fstream.readline())
-                atomic_row   = np.concatenate((fx, fy, fz))
-                dot_products = atomic_row @ inverse_a_subset
-                cluster_max  = max(cluster_max, float(np.max(dot_products)))
+                if component:
+                    for atomic_row in (fx, fy, fz):
+                        dot_products = atomic_row @ inverse_a_subset
+                        cluster_max  = max(cluster_max, float(np.max(dot_products)))
+                else:
+                    atomic_row   = np.concatenate((fx, fy, fz))
+                    dot_products = atomic_row @ inverse_a_subset
+                    cluster_max  = max(cluster_max, float(np.max(dot_products)))
 
             cluster_gamma.append(cluster_max)
             n_atoms_total += n_atoms
@@ -972,8 +1008,10 @@ def gen_subset_dopt(**kwargs):
 
     Algorithm:
         1. Stream-build A_atomic from the reference GEN_FF/A.txt (or A_comb.txt)
-           without loading the full A matrix into memory. Force rows (fx, fy, fz)
-           are hstacked per atom; FITENER energy rows are skipped per frame.
+           without loading the full A matrix into memory. By default force rows
+           (fx, fy, fz) are hstacked per atom; if component=True they are kept as
+           separate rows (the A matrix is left as-is). FITENER energy rows are
+           skipped per frame in both cases.
         2. Run maxvol on A_atomic to find the D-optimal subset (indices piv) and
            compute the inverse of the square submatrix A_atomic[piv].
         3. Submit a chimes_lsq job to generate descriptors for the candidate clusters
@@ -999,8 +1037,8 @@ def gen_subset_dopt(**kwargs):
     # 0. Set up argument parser
     ################################
 
-    default_keys   = [""]*16
-    default_values = [""]*16
+    default_keys   = [""]*17
+    default_values = [""]*17
 
     default_keys[0 ] = "gamma_min"     ; default_values[0 ] = 3.0
     default_keys[1 ] = "gamma_max"     ; default_values[1 ] = 10.0
@@ -1018,14 +1056,17 @@ def gen_subset_dopt(**kwargs):
     default_keys[13] = "job_email"     ; default_values[13] = True
     default_keys[14] = "job_modules"   ; default_values[14] = ""
     default_keys[15] = "job_executable"; default_values[15] = ""              # path to chimes_lsq
+    default_keys[16] = "component"     ; default_values[16] = False           # keep fx/fy/fz as separate rows (no hstack)
 
     args = dict(list(zip(default_keys, default_values)))
     args.update(kwargs)
 
     GAMMA_MIN = float(args["gamma_min"])
     GAMMA_MAX = float(args["gamma_max"])
+    COMPONENT = bool(args["component"])
 
-    print("gen_subset_dopt: gamma_min={}, gamma_max={}".format(GAMMA_MIN, GAMMA_MAX))
+    print("gen_subset_dopt: gamma_min={}, gamma_max={}, component={}".format(
+        GAMMA_MIN, GAMMA_MAX, COMPONENT))
 
     ################################
     # 1. Read candidate cluster lists
@@ -1140,7 +1181,8 @@ def gen_subset_dopt(**kwargs):
         ref_amat_path,
         fm_setup_path=args["fm_setup"],
         traj_list_path=traj_list_path if os.path.exists(traj_list_path) else None,
-        label="reference")
+        label="reference",
+        component=COMPONENT)
 
     print("gen_subset_dopt: A_atomic_ref shape:", A_atomic_ref.shape)
     np.savetxt("A_atomic.txt", A_atomic_ref)
@@ -1184,7 +1226,7 @@ def gen_subset_dopt(**kwargs):
     ################################
 
     cluster_gamma, n_atoms_cand = _compute_cluster_gamma_from_amat(
-        cand_amat_path, inverse_a_subset, all_clusters)
+        cand_amat_path, inverse_a_subset, all_clusters, component=COMPONENT)
 
     del inverse_a_subset
     gc.collect()

--- a/src/main.py
+++ b/src/main.py
@@ -499,6 +499,7 @@ def main(args):
                     n_dopt_sel = gen_selections.gen_subset_dopt(
                             gamma_min      = config.DOPT_GAMMA_MIN,
                             gamma_max      = config.DOPT_GAMMA_MAX,
+                            component      = config.DO_COMPONENT,
                             job_executable = config.CHIMES_LSQ,
                             job_nodes      = str(config.CHIMES_BUILD_NODES),
                             job_ppn        = str(config.HPC_PPN),
@@ -1095,6 +1096,7 @@ def main(args):
                         n_dopt_sel = gen_selections.gen_subset_dopt(
                                 gamma_min      = config.DOPT_GAMMA_MIN,
                                 gamma_max      = config.DOPT_GAMMA_MAX,
+                                component      = config.DO_COMPONENT,
                                 job_executable = config.CHIMES_LSQ,
                                 job_nodes      = str(config.CHIMES_BUILD_NODES),
                                 job_ppn        = str(config.HPC_PPN),

--- a/src/verify_config.py
+++ b/src/verify_config.py
@@ -91,6 +91,7 @@ def print_help():
     PARAM.append("DOPT_GAMMA_MIN");                 VARTYP.append("float");         DETAILS.append("Lower gamma threshold for D-optimality cluster selection (default: 3.0)")
     PARAM.append("DOPT_GAMMA_MAX");                 VARTYP.append("float");         DETAILS.append("Upper gamma threshold for D-optimality cluster selection (default: 10.0)")
     PARAM.append("DOPT_STOP_ON_EMPTY");             VARTYP.append("bool");          DETAILS.append("If true, stop active learning when D-opt selects zero clusters above the gamma threshold (default: True)")
+    PARAM.append("DO_COMPONENT");                    VARTYP.append("bool");          DETAILS.append("If true (and DO_DOPT is true), keep each force component row (fx, fy, fz) as its own row in the pseudo A matrix instead of hstacking the three into one per-atom row before maxvol (default: False)")
     PARAM.append("CALC_REPO_ENER_CENT_QUEUE");      VARTYP.append("str");           DETAILS.append("Queue to submit cluster ChIMES \"dumb\" energy calculations for central repository clusters to")
     PARAM.append("CALC_REPO_ENER_CENT_TIME");       VARTYP.append("str");           DETAILS.append("Walltime for ChIMES \"dumb\" energy calculations for central repository clusters")
     PARAM.append("CALC_REPO_ENER_QUEUE");           VARTYP.append("str");           DETAILS.append("Queue to submit cluster ChIMES \"dumb\" energy calculations for candidate clusters to")
@@ -1552,6 +1553,16 @@ def verify(user_config):
                 print("         Will use a value of True")
 
                 user_config.DOPT_STOP_ON_EMPTY = True
+
+            if not hasattr(user_config,'DO_COMPONENT'):
+
+                # Keep fx/fy/fz as separate rows in the pseudo A matrix instead of
+                # hstacking them into one per-atom row before maxvol?
+
+                print("WARNING: Option config.DO_COMPONENT was not set")
+                print("         Will use a value of False (hstack fx/fy/fz per atom)")
+
+                user_config.DO_COMPONENT = False
 
         if not hasattr(user_config,'CALC_REPO_ENER_CENT_QUEUE'):
 


### PR DESCRIPTION
## Summary

Adds a new `DO_COMPONENT` config flag to the D-optimality (maxvol) cluster
selection path. When enabled, the pseudo design matrix `A_atomic` is left as-is —
each force component row (`fx`, `fy`, `fz`) is kept as its own row of width
`n_feat` — instead of hstacking the three into one per-atom row of width
`3*n_feat` before maxvol.

The default (`False`) preserves the existing per-atom behavior, so this is a
non-breaking, opt-in change. Energy (FITENER) rows continue to be stripped in
both modes.

## Motivation

The current D-opt implementation defines atomic leverage on hstacked per-atom
force rows. Keeping the force components separate lets maxvol and the per-cluster
gamma scoring operate on the raw design-matrix rows, giving an alternative
(component-level) notion of D-optimality to evaluate.

## Changes

- **`src/gen_selections.py`**
  - `_fill_a_atomic_from_frames`: new `component` param — writes `fx/fy/fz` as
    three separate rows or one hstacked row.
  - `_build_a_atomic_from_file`: allocates `3*n_atoms × n_feat` vs
    `n_atoms × 3*n_feat` and validates the correct row count per mode.
  - `_compute_cluster_gamma_from_amat`: scores per-component or per-atom; the
    `inverse_A_subset` width check adjusts to `n_feat` vs `3*n_feat`.
  - `gen_subset_dopt`: new `component` kwarg (default `False`), threaded into the
    build/score helpers and logged at startup; docstring updated.
- **`src/main.py`**: both `gen_subset_dopt` call sites pass
  `component = config.DO_COMPONENT`.
- **`src/verify_config.py`**: `DO_COMPONENT` added to the parameter table and
  defaulted to `False` (within the `DO_DOPT` block, matching the other `DOPT_*`
  options).
- **`examples/cluster_based_active_learning_single_statepoint-VASP-dopt/config.py`**:
  documented `DO_COMPONENT = False`.
- **`README.md`**: added a "D-Optimality Cluster Selection" section documenting
  the method and all flags (`DO_DOPT`, `DOPT_GAMMA_MIN`, `DOPT_GAMMA_MAX`,
  `DOPT_STOP_ON_EMPTY`, `DO_COMPONENT`).

## Behavior / compatibility

- Default is `False` → identical to current behavior.
- `DO_COMPONENT` is only read when `DO_DOPT = True`; no effect on the MC
  energy-histogram path.
- maxvol still requires a tall matrix; in component mode the matrix is
  `3*n_atoms × n_feat`.

## Testing

- `python3 -m py_compile` passes for all modified files.
